### PR TITLE
Add Model and SerialNumber characteristic support

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -65,6 +65,14 @@
               "type": "string",
               "required": true
             },
+            "model": {
+              "title": "Model",
+              "type": "string"
+            },
+            "serialNumber": {
+              "title": "Serial Number",
+              "type": "string"
+            },
             "filterChangeLevel": {
               "title": "Filter Change Level",
               "description": "Percentage of filter life remaining to trigger a filter change alert.",
@@ -127,6 +135,8 @@
           "items": [
             "devices[].id",
             "devices[].name",
+            "devices[].model",
+            "devices[].serialNumber",
             "devices[].filterChangeLevel",
             "devices[].led",
             "devices[].airQualitySensor",

--- a/src/accessory/AirPurifierAccessory.ts
+++ b/src/accessory/AirPurifierAccessory.ts
@@ -23,7 +23,7 @@ export class AirPurifierAccessory {
       .getService(this.platform.Service.AccessoryInformation)!
       .setCharacteristic(this.platform.Characteristic.Manufacturer, 'BlueAir')
       .setCharacteristic(this.platform.Characteristic.Model, this.configDev.model || 'BlueAir Purifier')
-      .setCharacteristic(this.platform.Characteristic.SerialNumber, this.configDev.serial_number || 'BlueAir Device');
+      .setCharacteristic(this.platform.Characteristic.SerialNumber, this.configDev.serialNumber || 'BlueAir Device');
 
     this.service =
       this.accessory.getService(this.platform.Service.AirPurifier) || this.accessory.addService(this.platform.Service.AirPurifier);

--- a/src/accessory/AirPurifierAccessory.ts
+++ b/src/accessory/AirPurifierAccessory.ts
@@ -22,8 +22,8 @@ export class AirPurifierAccessory {
     this.accessory
       .getService(this.platform.Service.AccessoryInformation)!
       .setCharacteristic(this.platform.Characteristic.Manufacturer, 'BlueAir')
-      .setCharacteristic(this.platform.Characteristic.Model, this.configDev.model)
-      .setCharacteristic(this.platform.Characteristic.SerialNumber, this.configDev.serial_number);
+      .setCharacteristic(this.platform.Characteristic.Model, this.configDev.model || 'BlueAir Purifier')
+      .setCharacteristic(this.platform.Characteristic.SerialNumber, this.configDev.serial_number || 'BlueAir Device');
 
     this.service =
       this.accessory.getService(this.platform.Service.AirPurifier) || this.accessory.addService(this.platform.Service.AirPurifier);

--- a/src/accessory/AirPurifierAccessory.ts
+++ b/src/accessory/AirPurifierAccessory.ts
@@ -21,7 +21,9 @@ export class AirPurifierAccessory {
   ) {
     this.accessory
       .getService(this.platform.Service.AccessoryInformation)!
-      .setCharacteristic(this.platform.Characteristic.Manufacturer, 'BlueAir');
+      .setCharacteristic(this.platform.Characteristic.Manufacturer, 'BlueAir')
+      .setCharacteristic(this.platform.Characteristic.Model, this.configDev.model)
+      .setCharacteristic(this.platform.Characteristic.SerialNumber, this.configDev.serial_number);
 
     this.service =
       this.accessory.getService(this.platform.Service.AirPurifier) || this.accessory.addService(this.platform.Service.AirPurifier);

--- a/src/platformUtils.ts
+++ b/src/platformUtils.ts
@@ -14,7 +14,7 @@ export type DeviceConfig = {
   id: string;
   name: string;
   model: string;
-  serial_number: string;
+  serialNumber: string;
   filterChangeLevel: number;
   led: boolean;
   airQualitySensor: boolean;
@@ -57,7 +57,7 @@ export const defaultDeviceConfig: DeviceConfig = {
   id: '',
   name: '',
   model: '',
-  serial_number: '',
+  serialNumber: '',
   filterChangeLevel: 90,
   led: false,
   airQualitySensor: false,

--- a/src/platformUtils.ts
+++ b/src/platformUtils.ts
@@ -56,6 +56,8 @@ export const defaultConfig: Config = {
 export const defaultDeviceConfig: DeviceConfig = {
   id: '',
   name: '',
+  model: '',
+  serial_number: '',
   filterChangeLevel: 90,
   led: false,
   airQualitySensor: false,

--- a/src/platformUtils.ts
+++ b/src/platformUtils.ts
@@ -13,6 +13,8 @@ export type Config = {
 export type DeviceConfig = {
   id: string;
   name: string;
+  model: string;
+  serial_number: string;
   filterChangeLevel: number;
   led: boolean;
   airQualitySensor: boolean;


### PR DESCRIPTION
Some Homekit apps report issues when devices have the same serial number. This PR adds a Model and Serial Number field to the plugin to allow users to modify these, optionally.