### PR TITLE
fix: support split Blueair cloud regions

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -29,6 +29,12 @@
         "default": "Default (all other regions)",
         "required": true
       },
+      "cloudRegion": {
+        "title": "Cloud Region Override",
+        "description": "Optional BlueCloud device-control region. Leave unset to use Region. Some accounts authenticate in one region but their live device-control plane is in another.",
+        "type": "string",
+        "enum": ["Default (all other regions)", "Australia", "China", "Russia", "USA"]
+      },
       "accountUuid": {
         "title": "Account UUID",
         "description": "Account UUID for BlueAir account. This should be filled in automatically in the discovery process.",
@@ -117,7 +123,7 @@
           "expandable": true,
           "expanded": true,
           "title": "Common Settings",
-          "items": ["name", "username", "password", "region", "accountUuid", "verboseLogging", "uiDebug", "pollingInterval"]
+          "items": ["name", "username", "password", "region", "cloudRegion", "accountUuid", "verboseLogging", "uiDebug", "pollingInterval"]
         },
         {
           "key": "devices",

--- a/src/accessory/AirPurifierAccessory.ts
+++ b/src/accessory/AirPurifierAccessory.ts
@@ -244,7 +244,17 @@ export class AirPurifierAccessory {
 
   async setRotationSpeed(value: CharacteristicValue) {
     this.platform.log.debug(`[${this.device.name}] Setting rotation speed to ${value}`);
-    await this.device.setState('fanspeed', value as number);
+
+    const speed = value as number;
+    if (speed > 0 && this.device.state.standby === true) {
+      await this.device.setState('standby', false);
+    }
+
+    if (speed > 0 && this.device.state.automode === true) {
+      await this.device.setState('automode', false);
+    }
+
+    await this.device.setState('fanspeed', speed);
   }
 
   getFilterChangeIndication(): CharacteristicValue {

--- a/src/api/BlueAirAwsApi.ts
+++ b/src/api/BlueAirAwsApi.ts
@@ -79,6 +79,8 @@ export default class BlueAirAwsApi {
   private mutex: Mutex;
 
   private accessToken: string;
+  private idToken: string;
+  private userId: string;
   private blueAirApiUrl: string;
 
   constructor(
@@ -86,19 +88,22 @@ export default class BlueAirAwsApi {
     password: string,
     region: Region,
     private readonly logger: Logger,
+    cloudRegion: Region = region,
   ) {
-    const config = getAwsConfig(region);
+    const config = getAwsConfig(cloudRegion);
     this.blueAirApiUrl = `https://${config.restApiId}.execute-api.${config.awsRegion}.amazonaws.com/prod/c`;
 
     this.mutex = new Mutex();
 
     this.logger.debug(`Creating BlueAir API instance with config: ${JSON.stringify(config)} and username: ${username}\
-    and region: ${region}`);
+    and auth region: ${region}, cloud region: ${cloudRegion}`);
 
     this.gigyaApi = new GigyaApi(username, password, region, logger);
 
     this.last_login = 0;
     this.accessToken = '';
+    this.idToken = '';
+    this.userId = '';
   }
 
   async login(): Promise<void> {
@@ -106,10 +111,12 @@ export default class BlueAirAwsApi {
 
     const { token, secret } = await this.gigyaApi.getGigyaSession();
     const { jwt } = await this.gigyaApi.getGigyaJWT(token, secret);
-    const { accessToken } = await this.getAwsAccessToken(jwt);
+    const { accessToken, idToken, userId } = await this.getAwsAccessToken(jwt);
 
     this.last_login = Date.now();
     this.accessToken = accessToken;
+    this.idToken = idToken;
+    this.userId = userId;
 
     this.logger.debug('Logged in');
   }
@@ -147,7 +154,8 @@ export default class BlueAirAwsApi {
         include: uuids.map((uuid) => ({ filter: { o: `= ${uuid}` } })),
       },
     };
-    const data = await this.apiCall<BlueAirDeviceStatusResponse>(`/${accountUuid}/r/initial`, body);
+    const userId = this.userId || accountUuid;
+    const data = await this.apiCall<BlueAirDeviceStatusResponse>(`/${userId}/r/initial`, body);
 
     if (!data.deviceInfo) {
       throw new Error('getDeviceStatus error: no deviceInfo in response');
@@ -202,7 +210,7 @@ export default class BlueAirAwsApi {
     // this.logger.debug(`setDeviceStatus response: ${JSON.stringify(response)}`);
   }
 
-  private async getAwsAccessToken(jwt: string): Promise<{ accessToken: string }> {
+  private async getAwsAccessToken(jwt: string): Promise<{ accessToken: string; idToken: string; userId: string }> {
     this.logger.debug('Getting AWS access token...');
 
     const response = await this.apiCall('/login', undefined, 'POST', {
@@ -214,9 +222,16 @@ export default class BlueAirAwsApi {
       throw new Error(`AWS access token error: ${JSON.stringify(response)}`);
     }
 
+    const accessToken = response.access_token as string;
+    const tokenPayload = JSON.parse(Buffer.from(accessToken.split('.')[1].replace(/-/g, '+').replace(/_/g, '/'), 'base64').toString()) as {
+      username?: string;
+    };
+
     this.logger.debug('AWS access token received');
     return {
-      accessToken: response.access_token,
+      accessToken,
+      idToken: response.id_token ?? jwt,
+      userId: tokenPayload.username ?? '',
     };
   }
 
@@ -233,7 +248,7 @@ export default class BlueAirAwsApi {
           Connection: 'keep-alive',
           'Accept-Encoding': 'gzip, deflate, br',
           Authorization: `Bearer ${this.accessToken}`,
-          idtoken: this.accessToken,
+          idtoken: this.idToken || this.accessToken,
           ...headers,
         },
         body: JSON.stringify(data),

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -42,7 +42,13 @@ export class BlueAirPlatform extends EventEmitter implements DynamicPlatformPlug
       );
     }
 
-    this.blueAirApi = new BlueAirAwsApi(this.platformConfig.username, this.platformConfig.password, this.platformConfig.region, log);
+    this.blueAirApi = new BlueAirAwsApi(
+      this.platformConfig.username,
+      this.platformConfig.password,
+      this.platformConfig.region,
+      log,
+      this.platformConfig.cloudRegion ?? this.platformConfig.region,
+    );
 
     this.api.on('didFinishLaunching', async () => {
       await this.getInitialDeviceStates();

--- a/src/platformUtils.ts
+++ b/src/platformUtils.ts
@@ -3,6 +3,7 @@ export type Config = {
   username: string;
   password: string;
   region: Region;
+  cloudRegion?: Region;
   accountUuid: string;
   verboseLogging: boolean;
   uiDebug: boolean;


### PR DESCRIPTION
## Summary
- Adds an optional `cloudRegion` setting for the BlueCloud device-control endpoint while preserving the existing `region` setting for account authentication.
- Uses the BlueCloud access-token `username` claim for `/r/initial` state polling when available, with the configured account UUID as a fallback.
- Makes manual fan-speed writes wake the purifier and exit auto mode before setting `fanspeed`, so HomeKit manual speed changes are applied consistently.

## Why
Some Blueair accounts can authenticate in one region while their live device-control plane is served from another region. In that setup, HomeKit/Homebridge can accept writes locally while the configured regional BlueCloud endpoint returns stale state or no-op command responses. Separating auth region from control region lets the plugin target the active device-control endpoint without breaking existing single-region configs.

## Validation
- `npm run lint`
- `npm run build`
- Verified the change on a live split-region setup where HomeKit writes previously reverted on the next poll and now update the physical purifier state.

## Backward compatibility
Existing configs continue to work because `cloudRegion` is optional and defaults to `region`.

## AI assistance disclosure
This PR was prepared with AI agent assistance under human direction and review.
