### PR TITLE
Fix Blue Signature manual mode selection

### DIFF
--- a/src/accessory/AirPurifierAccessory.ts
+++ b/src/accessory/AirPurifierAccessory.ts
@@ -258,8 +258,9 @@ export class AirPurifierAccessory {
       await this.device.setState('standby', false);
     }
 
-    if (speed > 0 && this.device.state.automode === true) {
-      await this.device.setState('automode', false);
+    const manualMode = this.autoModeStrategy.setAuto(false);
+    if (speed > 0 && manualMode.attribute in this.device.state && this.device.state[manualMode.attribute] !== manualMode.value) {
+      await this.device.setState(manualMode.attribute, manualMode.value);
     }
 
     await this.device.setState('fanspeed', speed);

--- a/src/device/AutoModeStrategy.ts
+++ b/src/device/AutoModeStrategy.ts
@@ -12,11 +12,11 @@ const defaultStrategy: AutoModeStrategy = {
 };
 
 // Blue Signature devices don't expose `automode` at all; preset switching is
-// done exclusively through `apsubmode` (0=manual_fan, 2=auto, 3=night, 4=eco).
+// done exclusively through `apsubmode` (1=manual_fan, 2=auto, 3=night, 4=eco).
 // https://github.com/dahlb/ha_blueair issues #348/#261 (Signature owners' debug logs).
 const blueSignatureStrategy: AutoModeStrategy = {
   isAuto: (state) => state.apsubmode === 2,
-  setAuto: (isAuto) => ({ attribute: 'apsubmode', value: isAuto ? 2 : 0 }),
+  setAuto: (isAuto) => ({ attribute: 'apsubmode', value: isAuto ? 2 : 1 }),
 };
 
 const AUTO_MODE_STRATEGIES: Partial<Record<BlueAirDeviceType, AutoModeStrategy>> = {

--- a/test/manual-mode.cjs
+++ b/test/manual-mode.cjs
@@ -1,0 +1,69 @@
+// Run after building: node --test test/manual-mode.cjs
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { AirPurifierAccessory } = require('../dist/accessory/AirPurifierAccessory');
+const { getAutoModeStrategy } = require('../dist/device/AutoModeStrategy');
+const { BlueAirDeviceType } = require('../dist/device/BlueAirDeviceType');
+
+function fixture(state, type = BlueAirDeviceType.BLUE_SIGNATURE) {
+  const adapter = Object.create(AirPurifierAccessory.prototype);
+  const writes = [];
+  adapter.autoModeStrategy = getAutoModeStrategy(type);
+  adapter.platform = { log: { debug() {} }, Characteristic: { TargetAirPurifierState: { AUTO: 1, MANUAL: 0 } } };
+  adapter.device = {
+    name: 'Test purifier', state: { ...state },
+    async setState(attribute, value) {
+      assert.ok(attribute in this.state);
+      writes.push([attribute, value]);
+      this.state[attribute] = value;
+    },
+  };
+  return { adapter, writes };
+}
+
+test('Signature explicit Manual uses preset 1 and Auto uses preset 2', async () => {
+  const { adapter, writes } = fixture({ apsubmode: 2 });
+  await adapter.setTargetAirPurifierState(0);
+  assert.equal(adapter.getTargetAirPurifierState(), 0);
+  await adapter.setTargetAirPurifierState(1);
+  assert.equal(adapter.getTargetAirPurifierState(), 1);
+  assert.deepEqual(writes, [['apsubmode', 1], ['apsubmode', 2]]);
+});
+
+for (const preset of [2, 3, 4]) {
+  test(`Signature speed change exits preset ${preset} using Manual preset 1`, async () => {
+    const { adapter, writes } = fixture({ standby: false, apsubmode: preset, fanspeed: 11 });
+    await adapter.setRotationSpeed(33);
+    assert.deepEqual(writes, [['apsubmode', 1], ['fanspeed', 33]]);
+  });
+}
+
+test('Manual speed adjustment avoids redundant preset write', async () => {
+  const { adapter, writes } = fixture({ standby: false, apsubmode: 1, fanspeed: 11 });
+  await adapter.setRotationSpeed(33);
+  assert.deepEqual(writes, [['fanspeed', 33]]);
+});
+
+test('standby speed change wakes before changing mode and speed', async () => {
+  const { adapter, writes } = fixture({ standby: true, apsubmode: 2, fanspeed: 11 });
+  await adapter.setRotationSpeed(33);
+  assert.deepEqual(writes, [['standby', false], ['apsubmode', 1], ['fanspeed', 33]]);
+});
+
+test('zero speed does not wake device or switch preset', async () => {
+  const { adapter, writes } = fixture({ standby: true, apsubmode: 2, fanspeed: 11 });
+  await adapter.setRotationSpeed(0);
+  assert.deepEqual(writes, [['fanspeed', 0]]);
+});
+
+test('Blue Pure keeps the boolean automode command', async () => {
+  const { adapter, writes } = fixture({ standby: false, automode: true, fanspeed: 11 }, BlueAirDeviceType.BLUE_PURE);
+  await adapter.setRotationSpeed(33);
+  assert.deepEqual(writes, [['automode', false], ['fanspeed', 33]]);
+});
+
+test('device without a mode attribute can still change speed', async () => {
+  const { adapter, writes } = fixture({ standby: false, fanspeed: 11 }, BlueAirDeviceType.UNKNOWN);
+  await adapter.setRotationSpeed(33);
+  assert.deepEqual(writes, [['fanspeed', 33]]);
+});


### PR DESCRIPTION
## What does this PR do?

This PR fixes the Blue Signature Manual mode setting: `apsubmode` should be 1, not 0. It also fixes fan-speed changes checking `automode`, which these devices don't expose.

It's a small code change, with regression tests included. AI did the heavy lifting here.

## How was it tested?

I tested the isolated patch on my Blue Signature SP1i (model 4512311000), running firmware 1.1.2, and confirmed it works. The device reports `apsubmode=1` while powered on in Manual and `apsubmode=2` in Auto.

The isolated patch passes TypeScript compilation, lint with no warnings, and nine regression tests.

## AI assistance disclosure

Assisted-by: OpenAI Codex

---

**Checklist**

- [x] I read the [contribution guidelines](https://github.com/kovapatrik/homebridge-blueair-purifier/blob/HEAD/CONTRIBUTING.md)
- [x] If this PR used AI assistance, I followed the [AI Contribution Policy](https://github.com/kovapatrik/homebridge-blueair-purifier/blob/HEAD/CONTRIBUTING.md#ai-policy)
- [x] I tested this on real hardware (required for device-specific changes)
- [x] I ran the lint check and there are no warnings
