### PR TITLE
fix: recover gracefully from BlueAir rate-limit responses (229/429)

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -52,7 +52,7 @@
       },
       "pollingInterval": {
         "title": "Polling Interval",
-        "description": "Interval in miliseconds to poll the BlueAir API for updates. It's recommended to keep this at least 15 seconds (15000 miliseconds).",
+        "description": "Interval in milliseconds to poll the BlueAir API for updates. Recommended minimum is 30000 (30 seconds). The plugin will automatically back off when the API returns a rate-limit response (status 229 or 429).",
         "type": "number"
       },
       "devices": {

--- a/config.schema.json
+++ b/config.schema.json
@@ -52,7 +52,7 @@
       },
       "pollingInterval": {
         "title": "Polling Interval",
-        "description": "Interval in milliseconds to poll the BlueAir API for updates. Recommended minimum is 30000 (30 seconds). The plugin will automatically back off when the API returns a rate-limit response (status 229 or 429).",
+        "description": "Interval in milliseconds to poll the BlueAir API for updates. Note that BlueAir's own API docs state device data only refreshes on their servers every 5 minutes, so polling faster than that returns the same data. The plugin automatically backs off when the API returns a rate-limit response (status 229 or 429).",
         "type": "number"
       },
       "devices": {

--- a/config.schema.json
+++ b/config.schema.json
@@ -52,7 +52,7 @@
       },
       "pollingInterval": {
         "title": "Polling Interval",
-        "description": "Interval in milliseconds to poll the BlueAir API for updates. Note that BlueAir's own API docs state device data only refreshes on their servers every 5 minutes, so polling faster than that returns the same data. The plugin automatically backs off when the API returns a rate-limit response (status 229 or 429).",
+        "description": "Interval in milliseconds to poll the BlueAir API for updates. The plugin automatically backs off when the API returns a rate-limit response (status 229 or 429). Note: BlueAir's rate limit is applied per account, so faster polling from this plugin can trigger throttling that also affects the BlueAir mobile app. For older devices without real-time sensors (Blue 40, Dust Magnet series) the plugin falls back to a 5-minute aggregated telemetry endpoint, so polling those faster than 5 min will not surface fresher sensor readings.",
         "type": "number"
       },
       "devices": {

--- a/src/api/BlueAirAwsApi.ts
+++ b/src/api/BlueAirAwsApi.ts
@@ -1,7 +1,16 @@
 import { Logger } from 'homebridge';
 import { Region } from '../platformUtils';
 import GigyaApi from './GigyaApi';
-import { BLUEAIR_API_TIMEOUT, BlueAirDeviceStatusResponse, BlueAirTelemetryResponse, LOGIN_EXPIRATION, getAwsConfig } from './Consts';
+import {
+  BLUEAIR_API_TIMEOUT,
+  BLUEAIR_RATE_LIMIT_STATUSES,
+  BLUEAIR_RETRY_BASE_MS,
+  BLUEAIR_RETRY_MAX_MS,
+  BlueAirDeviceStatusResponse,
+  BlueAirTelemetryResponse,
+  LOGIN_EXPIRATION,
+  getAwsConfig,
+} from './Consts';
 import { Mutex } from 'async-mutex';
 
 type BlueAirDeviceDiscovery = {
@@ -61,6 +70,23 @@ type BlueAirSetStateBody = {
   v?: number;
   vb?: boolean;
 };
+
+export class RateLimitError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RateLimitError';
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function computeBackoffMs(attempt: number): number {
+  const exponential = BLUEAIR_RETRY_BASE_MS * 2 ** attempt;
+  const jitter = Math.floor(Math.random() * BLUEAIR_RETRY_BASE_MS);
+  return Math.min(exponential + jitter, BLUEAIR_RETRY_MAX_MS);
+}
 
 export const BlueAirDeviceSensorDataMap: Record<string, keyof BlueAirDeviceSensorData> = {
   fsp0: 'fanspeed',
@@ -332,41 +358,76 @@ export default class BlueAirAwsApi {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   private async apiCall<T = any>(url: string, data?: string | object, method = 'POST', headers?: object, retries = 3): Promise<T> {
     const release = await this.mutex.acquire();
-    const controller = new AbortController();
-    const timeout = setTimeout(() => controller.abort(), BLUEAIR_API_TIMEOUT);
-    this.logger.debug(`[AWS] apiCall request: ${method} ${this.blueAirApiUrl}${url}, body: ${JSON.stringify(data)}`);
     try {
-      const response = await fetch(`${this.blueAirApiUrl}${url}`, {
-        method: method,
-        headers: {
-          Accept: '*/*',
-          Connection: 'keep-alive',
-          'Accept-Encoding': 'gzip, deflate, br',
-          Authorization: `Bearer ${this.accessToken}`,
-          idtoken: this.idToken || this.accessToken,
-          ...headers,
-        },
-        body: JSON.stringify(data),
-        signal: controller.signal,
-      });
-      const json = await response.json();
-      this.logger.debug(`[AWS] apiCall response: ${response.status} ${response.statusText}, body: ${JSON.stringify(json)}`);
-      if (response.status !== 200) {
-        throw new Error(`API call error with status ${response.status}: ${response.statusText}, ${JSON.stringify(json)}`);
-      }
-      return json as T;
-    } catch (error) {
-      if (retries > 0) {
-        return this.apiCall(url, data, method, headers, retries - 1);
-      } else {
-        if (error instanceof Error && error.name === 'AbortError') {
-          throw new Error(`API call failed after ${3 - retries} retries with timeout.`);
-        } else {
-          throw new Error(`API call failed after ${3 - retries} retries with error: ${error}`);
+      for (let attempt = 0; ; attempt++) {
+        const controller = new AbortController();
+        const timeout = setTimeout(() => controller.abort(), BLUEAIR_API_TIMEOUT);
+        this.logger.debug(`[AWS] apiCall request: ${method} ${this.blueAirApiUrl}${url}, body: ${JSON.stringify(data)}`);
+
+        let response: Response;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        let json: any;
+        try {
+          response = await fetch(`${this.blueAirApiUrl}${url}`, {
+            method: method,
+            headers: {
+              Accept: '*/*',
+              Connection: 'keep-alive',
+              'Accept-Encoding': 'gzip, deflate, br',
+              Authorization: `Bearer ${this.accessToken}`,
+              idtoken: this.idToken || this.accessToken,
+              ...headers,
+            },
+            body: JSON.stringify(data),
+            signal: controller.signal,
+          });
+          json = await response.json();
+        } catch (error) {
+          clearTimeout(timeout);
+          const err = error as Error;
+          const description = err.name === 'AbortError' ? 'API call timed out' : `API call error: ${err.message}`;
+          if (attempt >= retries) {
+            throw new Error(`${description} (after ${attempt + 1} attempts)`);
+          }
+          const delayMs = computeBackoffMs(attempt);
+          this.logger.debug(`[AWS] ${description} on attempt ${attempt + 1}, retrying in ${delayMs}ms`);
+          await sleep(delayMs);
+          continue;
         }
+        clearTimeout(timeout);
+
+        this.logger.debug(`[AWS] apiCall response: ${response.status} ${response.statusText}, body: ${JSON.stringify(json)}`);
+
+        if (response.status === 200) {
+          return json as T;
+        }
+
+        const message = `API call error with status ${response.status}: ${response.statusText}, ${JSON.stringify(json)}`;
+
+        if (BLUEAIR_RATE_LIMIT_STATUSES.has(response.status)) {
+          if (attempt >= retries) {
+            throw new RateLimitError(`${message} (after ${attempt + 1} attempts)`);
+          }
+          const delayMs = computeBackoffMs(attempt);
+          this.logger.debug(`[AWS] rate-limited (status ${response.status}) on attempt ${attempt + 1}, retrying in ${delayMs}ms`);
+          await sleep(delayMs);
+          continue;
+        }
+
+        if (response.status >= 500) {
+          if (attempt >= retries) {
+            throw new Error(`${message} (after ${attempt + 1} attempts)`);
+          }
+          const delayMs = computeBackoffMs(attempt);
+          this.logger.debug(`[AWS] server error (status ${response.status}) on attempt ${attempt + 1}, retrying in ${delayMs}ms`);
+          await sleep(delayMs);
+          continue;
+        }
+
+        // Non-retryable client error (e.g. 400, 401, 403, 404).
+        throw new Error(message);
       }
     } finally {
-      clearTimeout(timeout);
       release();
     }
   }

--- a/src/api/BlueAirAwsApi.ts
+++ b/src/api/BlueAirAwsApi.ts
@@ -405,10 +405,10 @@ export default class BlueAirAwsApi {
         const message = `API call error with status ${response.status}: ${response.statusText}, ${JSON.stringify(json)}`;
 
         if (BLUEAIR_RATE_LIMIT_STATUSES.has(response.status)) {
-          // BlueAir's own docs say the underlying data only refreshes every 5 minutes.
-          // Retrying a rate-limit response within seconds definitionally fetches the
-          // same stale data — and extends the throttle window for the whole account.
-          // Fail fast; let the platform-level backoff decide when to try again.
+          // Retrying a rate-limit response immediately is what got us throttled in the
+          // first place — and since BlueAir's throttle is account-scoped, every extra
+          // request extends the pain for the user's own mobile app as well. Fail fast;
+          // let the platform-level backoff decide when to try again.
           throw new RateLimitError(message);
         }
 

--- a/src/api/BlueAirAwsApi.ts
+++ b/src/api/BlueAirAwsApi.ts
@@ -405,13 +405,11 @@ export default class BlueAirAwsApi {
         const message = `API call error with status ${response.status}: ${response.statusText}, ${JSON.stringify(json)}`;
 
         if (BLUEAIR_RATE_LIMIT_STATUSES.has(response.status)) {
-          if (attempt >= retries) {
-            throw new RateLimitError(`${message} (after ${attempt + 1} attempts)`);
-          }
-          const delayMs = computeBackoffMs(attempt);
-          this.logger.debug(`[AWS] rate-limited (status ${response.status}) on attempt ${attempt + 1}, retrying in ${delayMs}ms`);
-          await sleep(delayMs);
-          continue;
+          // BlueAir's own docs say the underlying data only refreshes every 5 minutes.
+          // Retrying a rate-limit response within seconds definitionally fetches the
+          // same stale data — and extends the throttle window for the whole account.
+          // Fail fast; let the platform-level backoff decide when to try again.
+          throw new RateLimitError(message);
         }
 
         if (response.status >= 500) {

--- a/src/api/Consts.ts
+++ b/src/api/Consts.ts
@@ -59,6 +59,11 @@ export function getGigyaConfig(region: Region): GigyaConfigValue {
 export const LOGIN_EXPIRATION = 3600 * 1000 * 24; // n hours in milliseconds
 export const BLUEAIR_API_TIMEOUT = 5 * 1000; // n seconds in milliseconds
 
+export const BLUEAIR_RETRY_BASE_MS = 1000;
+export const BLUEAIR_RETRY_MAX_MS = 30 * 1000;
+// 229 is the non-standard status the BlueAir AWS API returns for "too many calls".
+export const BLUEAIR_RATE_LIMIT_STATUSES: ReadonlySet<number> = new Set([229, 429]);
+
 export type BlueAirDeviceStatusResponse = {
   deviceInfo: {
     id: string;

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -65,11 +65,13 @@ export class BlueAirPlatform extends EventEmitter implements DynamicPlatformPlug
     this.accessories.push(accessory);
   }
 
-  // Exponential backoff of the outer poll on repeated rate-limits: 1x, 2x, 4x, 8x, 16x,
-  // then hard-capped at MAX_POLL_BACKOFF_MS so the plugin never goes silent for longer
-  // than that regardless of pollingInterval.
+  // Exponential backoff of the outer poll on repeated rate-limits: 1x, 2x, 4x, 8x, ...
+  // Ceiling is the absolute MAX_POLL_BACKOFF_MS rather than a multiplier cap, so the
+  // max silence is the same (~30 min) regardless of pollingInterval. Letting the counter
+  // grow unbounded also makes decay-on-success a proper gradual ramp — a long jail
+  // requires proportionally many successful polls to fully recover.
   private computeBackoffDelayMs(): number {
-    const multiplier = 2 ** Math.min(this.consecutiveRateLimitFailures, 4);
+    const multiplier = 2 ** this.consecutiveRateLimitFailures;
     return Math.min(this.platformConfig.pollingInterval * multiplier, MAX_POLL_BACKOFF_MS);
   }
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -8,6 +8,10 @@ import { BlueAirDevice } from './device/BlueAirDevice';
 import { AirPurifierAccessory } from './accessory/AirPurifierAccessory';
 import EventEmitter from 'events';
 
+// Absolute ceiling on the polling backoff. Prevents the plugin from going silent for
+// hours at large pollingInterval bases (e.g. 5 min * 16 = 80 min without this cap).
+const MAX_POLL_BACKOFF_MS = 30 * 60 * 1000;
+
 export class BlueAirPlatform extends EventEmitter implements DynamicPlatformPlugin {
   public readonly Service: typeof Service;
   public readonly Characteristic: typeof Characteristic;
@@ -51,16 +55,38 @@ export class BlueAirPlatform extends EventEmitter implements DynamicPlatformPlug
       this.platformConfig.cloudRegion ?? this.platformConfig.region,
     );
 
-    this.api.on('didFinishLaunching', async () => {
-      await this.getInitialDeviceStates();
-
-      this.getValidDevicesStatus();
+    this.api.on('didFinishLaunching', () => {
+      this.initializeAndStartPolling();
     });
   }
 
   configureAccessory(accessory: PlatformAccessory) {
     this.log.info('Loading accessory from cache:', accessory.displayName);
     this.accessories.push(accessory);
+  }
+
+  // Exponential backoff of the outer poll on repeated rate-limits: 1x, 2x, 4x, 8x, 16x,
+  // then hard-capped at MAX_POLL_BACKOFF_MS so the plugin never goes silent for longer
+  // than that regardless of pollingInterval.
+  private computeBackoffDelayMs(): number {
+    const multiplier = 2 ** Math.min(this.consecutiveRateLimitFailures, 4);
+    return Math.min(this.platformConfig.pollingInterval * multiplier, MAX_POLL_BACKOFF_MS);
+  }
+
+  private async initializeAndStartPolling() {
+    try {
+      await this.getInitialDeviceStates();
+      // Decay on success rather than reset so a single lucky poll doesn't immediately
+      // put us back at the configured cadence and re-trip the throttle.
+      this.consecutiveRateLimitFailures = Math.max(0, this.consecutiveRateLimitFailures - 1);
+      this.getValidDevicesStatus();
+    } catch (error) {
+      // Only RateLimitError bubbles out; other errors are swallowed inside getInitialDeviceStates.
+      this.consecutiveRateLimitFailures++;
+      const delayMs = this.computeBackoffDelayMs();
+      this.log.warn(`Rate-limited during initial device fetch: ${(error as Error).message}. Retrying initialization in ${delayMs}ms...`);
+      setTimeout(() => this.initializeAndStartPolling(), delayMs);
+    }
   }
 
   async getValidDevicesStatus() {
@@ -78,14 +104,12 @@ export class BlueAirPlatform extends EventEmitter implements DynamicPlatformPlug
         blueAirDevice.emit('update', device);
       }
       this.log.debug('Devices states updated!');
-      this.consecutiveRateLimitFailures = 0;
+      this.consecutiveRateLimitFailures = Math.max(0, this.consecutiveRateLimitFailures - 1);
     } catch (error) {
       const err = error as Error;
       if (error instanceof RateLimitError) {
         this.consecutiveRateLimitFailures++;
-        // Exponential backoff of the outer poll on repeated rate-limits: 1x, 2x, 4x, 8x, 16x cap.
-        const multiplier = 2 ** Math.min(this.consecutiveRateLimitFailures, 4);
-        nextDelayMs = this.platformConfig.pollingInterval * multiplier;
+        nextDelayMs = this.computeBackoffDelayMs();
       }
       this.log.warn(`Error getting valid devices status, reason: ${err.message}. Retrying in ${nextDelayMs}ms...`);
       this.log.debug('Error stack:', err.stack);
@@ -113,6 +137,10 @@ export class BlueAirPlatform extends EventEmitter implements DynamicPlatformPlug
 
       this.log.info('All configured devices have been added!');
     } catch (error) {
+      if (error instanceof RateLimitError) {
+        // Let initializeAndStartPolling apply the outer backoff.
+        throw error;
+      }
       this.log.error('Error getting initial device states:', error);
     }
   }
@@ -141,7 +169,7 @@ export class BlueAirPlatform extends EventEmitter implements DynamicPlatformPlug
       try {
         await this.blueAirApi.setDeviceStatus(id, attribute, value);
         success = true;
-        this.consecutiveRateLimitFailures = 0;
+        this.consecutiveRateLimitFailures = Math.max(0, this.consecutiveRateLimitFailures - 1);
       } catch (error) {
         this.log.error(`[${name}] Error setting state: ${attribute} = ${value}`, error);
       } finally {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -87,7 +87,10 @@ export class BlueAirPlatform extends EventEmitter implements DynamicPlatformPlug
       this.consecutiveRateLimitFailures++;
       const delayMs = this.computeBackoffDelayMs();
       this.log.warn(`Rate-limited during initial device fetch: ${(error as Error).message}. Retrying initialization in ${delayMs}ms...`);
-      setTimeout(() => this.initializeAndStartPolling(), delayMs);
+      if (this.polling) {
+        clearTimeout(this.polling);
+      }
+      this.polling = setTimeout(() => this.initializeAndStartPolling(), delayMs);
     }
   }
 
@@ -116,6 +119,12 @@ export class BlueAirPlatform extends EventEmitter implements DynamicPlatformPlug
       this.log.warn(`Error getting valid devices status, reason: ${err.message}. Retrying in ${nextDelayMs}ms...`);
       this.log.debug('Error stack:', err.stack);
     } finally {
+      // Defensive clear: a concurrent setState may have scheduled its own poll while we
+      // were awaiting the API. Without this, both timers stay active and create parallel
+      // polling loops (visible in logs as two identical warns in the same second).
+      if (this.polling) {
+        clearTimeout(this.polling);
+      }
       this.polling = setTimeout(this.getValidDevicesStatus.bind(this), nextDelayMs);
     }
   }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -3,7 +3,7 @@ import { API, DynamicPlatformPlugin, Logger, PlatformAccessory, PlatformConfig, 
 import { PLATFORM_NAME, PLUGIN_NAME } from './settings';
 import { Config, defaultConfig } from './platformUtils';
 import { defaultsDeep } from 'lodash';
-import BlueAirAwsApi, { BlueAirDeviceStatus } from './api/BlueAirAwsApi';
+import BlueAirAwsApi, { BlueAirDeviceStatus, RateLimitError } from './api/BlueAirAwsApi';
 import { BlueAirDevice } from './device/BlueAirDevice';
 import { AirPurifierAccessory } from './accessory/AirPurifierAccessory';
 import EventEmitter from 'events';
@@ -22,6 +22,7 @@ export class BlueAirPlatform extends EventEmitter implements DynamicPlatformPlug
 
   private devices: BlueAirDevice[] = [];
   private polling: NodeJS.Timeout | null = null;
+  private consecutiveRateLimitFailures = 0;
 
   constructor(
     public readonly log: Logger,
@@ -64,6 +65,7 @@ export class BlueAirPlatform extends EventEmitter implements DynamicPlatformPlug
 
   async getValidDevicesStatus() {
     this.log.debug('Updating devices states...');
+    let nextDelayMs = this.platformConfig.pollingInterval;
     try {
       const devices = await this.blueAirApi.getDeviceStatus(this.platformConfig.accountUuid, this.existingUuids);
       for (const device of devices) {
@@ -76,12 +78,19 @@ export class BlueAirPlatform extends EventEmitter implements DynamicPlatformPlug
         blueAirDevice.emit('update', device);
       }
       this.log.debug('Devices states updated!');
+      this.consecutiveRateLimitFailures = 0;
     } catch (error) {
       const err = error as Error;
-      this.log.warn('Error getting valid devices status, reason:' + err.message + '. Retrying in 5 seconds...');
+      if (error instanceof RateLimitError) {
+        this.consecutiveRateLimitFailures++;
+        // Exponential backoff of the outer poll on repeated rate-limits: 1x, 2x, 4x, 8x, 16x cap.
+        const multiplier = 2 ** Math.min(this.consecutiveRateLimitFailures, 4);
+        nextDelayMs = this.platformConfig.pollingInterval * multiplier;
+      }
+      this.log.warn(`Error getting valid devices status, reason: ${err.message}. Retrying in ${nextDelayMs}ms...`);
       this.log.debug('Error stack:', err.stack);
     } finally {
-      this.polling = setTimeout(this.getValidDevicesStatus.bind(this), this.platformConfig.pollingInterval);
+      this.polling = setTimeout(this.getValidDevicesStatus.bind(this), nextDelayMs);
     }
   }
 
@@ -132,6 +141,7 @@ export class BlueAirPlatform extends EventEmitter implements DynamicPlatformPlug
       try {
         await this.blueAirApi.setDeviceStatus(id, attribute, value);
         success = true;
+        this.consecutiveRateLimitFailures = 0;
       } catch (error) {
         this.log.error(`[${name}] Error setting state: ${attribute} = ${value}`, error);
       } finally {

--- a/src/platformUtils.ts
+++ b/src/platformUtils.ts
@@ -42,7 +42,7 @@ export const defaultConfig: Config = {
   password: '',
   accountUuid: '',
   region: Region.EU,
-  pollingInterval: 30000,
+  pollingInterval: 15000,
   devices: [],
 };
 

--- a/src/platformUtils.ts
+++ b/src/platformUtils.ts
@@ -42,7 +42,7 @@ export const defaultConfig: Config = {
   password: '',
   accountUuid: '',
   region: Region.EU,
-  pollingInterval: 15000,
+  pollingInterval: 30000,
   devices: [],
 };
 


### PR DESCRIPTION
## What does this PR do?

### Summary

- Addresses BlueAir rate-limit lockouts that leave the plugin and the user's own BlueAir app stuck (see https://github.com/kovapatrik/homebridge-blueair-purifier/issues/41)
- Reworks `apiCall` and the polling loop so a 229 response becomes a self-recovering event instead of a persistent 4-request-per-cycle storm

### Root Cause

BlueAir's API returns a non-standard status 229 ("too many calls") when a client hits its rate limit. That rate limit is account-scoped, so tripping it also blocks the BlueAir mobile app for the same user, not just this plugin. 

Users on the current defaults (`pollingInterval`: `15000`) are getting stuck in this state and unable to recover without restarting Homebridge.

The root cause is that `apiCall` treats a 229 like any other non-200 error and immediately retries three times back-to-back with no delay, while `getValidDevicesStatus` unconditionally reschedules the next poll at the flat configured interval regardless of outcome. 

So a single 229 produces four rapid-fire requests, and that four-request storm repeats every pollingInterval indefinitely. This actively extends the throttle window for the whole account. `getInitialDeviceStates` has the same problem on startup and no backoff at all, so a rate-limited restart fires eight back-to-back requests before the outer poll can even engage.

### Changes in this PR

1. `apiCall` now throws a new `RateLimitError` on the first 229/429 instead of retrying. 5xx and network errors still retry with exponential backoff + jitter; other 4xx errors bubble up immediately
2. `getValidDevicesStatus` tracks a `consecutiveRateLimitFailures` counter and multiplies the next poll delay by 2^N, capped by an absolute `MAX_POLL_BACKOFF_MS` = 30 min 
  - Successful polls (and successful `setState` writes) decay the counter by 1 instead of resetting to 0, so recovery from deep backoff is gradual instead of snap-back
3. `getInitialDeviceStates` participates in the same backoff via a new `initializeAndStartPolling` handler
4.  Defensive `clearTimeout` before every `this.polling = setTimeout(...)` prevents orphaned parallel polling loops when a `setState` call overlaps with an in-flight poll
5. Misleading hardcoded "Retrying in 5 seconds..." log line now reports the actual computed delay. Schema description for `pollingInterval` updated to explain the account-scoped throttle and the 5-min aggregation on the historical telemetry fallback used for older devices.

#### Out of scope for this PR:

- Default `pollingInterval` is unchanged at 15 s. Bumping the default is a separable policy call; these changes make the plugin resilient at any interval a user chooses
- No unit tests added; the repo has no test infrastructure and introducing it is its own change.

## How was it tested?

- [X] Repo has no unit-test infrastructure, so manual testing only
- [X] I installed the development version of the plugin on my HB instance and ran the following 7 tests. The summary of the tests are AI-generated, but I validated the success of each test manually

### Manual Test Summary
Environment: Homebridge v2.4.0, official docker image on Raspberry Pi, single BlueAir Protect device.

#### Test 1: Steady-state soak at default `pollingInterval: 15000`

**Status:** PASS (14 min soak from 6:06:52 PM to 6:20 PM). Zero `blueair-purifier` warns during the window. Tests 2 and 3 were run concurrently (HomeKit toggles, external state change) and produced no additional API pressure sufficient to trip 229. 

#### Test 2: HomeKit write path

**Status:** PASS. Toggled Active on/off, changed fan speed multiple times, toggled LED. All commands took effect on the physical device within ~1 s. Home app UI stayed consistent. No 229s or other warns correlated with the toggles.

#### Test 3: External state sync

**Status:** PASS. Started at 6:11 PM — changed state externally, Home app reflected within ~10 seconds. Confirms poll → emit → updateCharacteristic path works and state (not sensor) data is near-realtime from the `/r/initial` endpoint.

#### Test 4: Rate-limit trigger and graceful handling

**Status:** PASS. Set `pollingInterval: 2000` at 6:21:45 PM, first 229 at 6:22:36 PM. Observed sequence:

| Time | Delay | Counter | Multiplier |
|---|---|---|---|
| 6:22:36 | 4000 | 1 | 2× |
| 6:22:41 | 8000 | 2 | 4× |
| 6:22:49 | 16000 | 3 | 8× |
| 6:23:05 | 32000 | 4 | 16× |
| 6:23:39 | 32000 | 4 | 16× (setState decay masked increment) |
| 6:23:41 | 32000 | 4 | 16× |
| 6:24:14 | 64000 | 5 | 32× — **past old cap, Item 4 verified** |
| 6:25:37 | 4000 | 1 | 2× — after silent recovery, Item 2 verified |

- **Item 1 (retry-removal):** VERIFIED. No warn contains `(after N attempts)` throughout the sequence.
- **Item 4 (multiplier cap removed):** VERIFIED at `64000ms` = 32×, beyond the pre-fix 16× ceiling.
- **Absolute cap `MAX_POLL_BACKOFF_MS = 1800000`:** not directly observed (recovery happened before counter climbed high enough), but derived trivially from the code path exercised.

#### Test 5: Concurrent-loop fix

**Status:** PASS. During the Test 4 aggressive-polling window (`pollingInterval: 2000` from 6:22 to 6:26 PM), the Home app was actively used to toggle Active (at least 2 times) while 229s were being raised in the log. No same-timestamp duplicate warns appeared anywhere in the sequence; compare to prior pre-fix logs at 5:47:19 PM and 5:56:28 PM which each showed two same-second warns with different `Retrying in Xms` values. The defensive `clearTimeout` before every `setTimeout` on `this.polling` is preventing orphaned parallel polling loops.

#### Test 6: Decay on success

**Status:** PASS. Observed during Test 4 run. After a 64s wait at counter=5, silent successful polls decayed the counter through 5 → 4 → 3 → 2 → 1 → 0 over ~10 seconds of 2s-cadence polling. Confirmed by the next 229 at 6:25:37 producing `Retrying in 4000ms` (= counter went 0→1, i.e. fresh escalation), not a re-cap. Under the old reset-to-0 design the visible result at 2s polling would be the same but for the wrong reason; the mechanism is verifiable in the code path (single decrement, not assignment to 0) and its behavior becomes visibly gradual at longer `pollingInterval` values.

#### Test 7: Initial-state backoff

**Status:** PASS. Restarted Homebridge at 6:27:39 PM while the account was still throttled from Test 4. Observed:

| Time | Log |
|---|---|
| 6:27:40 | `Rate-limited during initial device fetch: ... Retrying initialization in 4000ms...` |
| 6:27:44 | `Getting initial device states...` (4s after previous warn — matches schedule) |
| 6:27:46 | `Rate-limited during initial device fetch: ... Retrying initialization in 8000ms...` |

All Item 3 criteria met:
- New log-message format present (`Rate-limited during initial device fetch: ...`) — not the pre-fix `Error getting valid devices states` message
- One warn per attempt, not a 4-attempt burst
- Escalating delays (`4000 → 8000`, matching `pollingInterval × 2^N`)
- No `Error getting valid devices status` warns during the initialization phase — polling correctly deferred until initial fetch succeeds
- No `(after N attempts)` suffix — Item 1 also honored on the initial-fetch path

## AI assistance disclosure

- I used Claude Opus to implement the fixes
- The test plan was created with Claude assistance but manually verified by me
- Each line of code was validated by me

---

**Checklist**

- [X] I read the [contribution guidelines](https://github.com/kovapatrik/homebridge-blueair-purifier/blob/HEAD/CONTRIBUTING.md)
- [X] If this PR used AI assistance, I followed the [AI Contribution Policy](https://github.com/kovapatrik/homebridge-blueair-purifier/blob/HEAD/CONTRIBUTING.md#ai-policy)
- [X] I tested this on real hardware (required for device-specific changes)
- [X] I ran `npm run lint` and there are no warnings
